### PR TITLE
updates browserstack hub url

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ npm install nightwatch-browserstack
 ```js
 module.exports = {
   beforeEach: function (browser, done) {
-    if (this.test_settings.selenium_host === 'hub.browserstack.com') {
+    if (this.test_settings.selenium_host === 'hub-cloud.browserstack.com') {
       return require('nightwatch-browserstack').storeSessionId(browser, done)
     }
     done()
   },
   afterEach: function (browser, done) {
-    if (this.test_settings.selenium_host === 'hub.browserstack.com') {
+    if (this.test_settings.selenium_host === 'hub-cloud.browserstack.com') {
       return require('nightwatch-browserstack').updateStatus(browser, done)
     }
     done()


### PR DESCRIPTION
You're being linked to from [browserstack/nightwatch-browserstack](https://github.com/browserstack/nightwatch-browserstack), so I thought I'd put in a PR to update the BrowserStack hub URLs this repo is using.