### PR TITLE
Feature: Send status on errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,9 +18,9 @@ module.exports = {
     })
   },
   updateStatus: function (browser, done) {
-    if (browser.currentTest.results.failed) {
+    if (browser.currentTest.results.failed || browser.currentTest.results.errors) {
       let caps = browser.globals.test_settings.desiredCapabilities
-      let user = caps['browserstack.user']
+      let user = browser.globals.test_settings.desiredCapabilities.browser.user;
       let key = caps['browserstack.key']
       let options = {
         host: 'www.browserstack.com',

--- a/index.js
+++ b/index.js
@@ -19,10 +19,10 @@ module.exports = {
   },
   updateStatus: function (browser, done) {
     if (browser.currentTest.results.failed || browser.currentTest.results.errors) {
-      let caps = browser.globals.test_settings.desiredCapabilities
-      let user = browser.globals.test_settings.desiredCapabilities.browser.user;
-      let key = caps['browserstack.key']
-      let options = {
+      const caps = browser.globals.test_settings.desiredCapabilities
+      const user = caps['browserstack.user']
+      const key = caps['browserstack.key']
+      const options = {
         host: 'www.browserstack.com',
         path: `/automate/sessions/${browser.browserStackSessionId}.json`,
         method: 'PUT',


### PR DESCRIPTION
Thanks for making this @blueimp! I just ran into an issue where it was sending a status only when `failed` was set, I also need it to send a status if there's an `error`. 